### PR TITLE
initial commit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: '{build}'
+skip_tags: true
+image: Visual Studio 2017
+configuration: Release
+build_script:
+- ps: ./Build.ps1
+test: off
+artifacts:
+- path: artifacts/Serilog.*.nupkg
+deploy:
+- provider: NuGet
+  api_key:
+    secure: m+/Qa/R0Z/kyTzdYapp++w7AW3sTMbmsz/4cHV9H4kPApgb8O1HjMfdiGLnBBHDv
+  skip_symbols: true
+  on:
+    branch: /^(master|dev)$/
+- provider: GitHub
+  auth_token:
+    secure: +EUQOpgfGayDA+QMrOqaI9wi2mUYdI3RrTU2hJNTMAIfBm/HAIQkCPxIGx+8nDeA
+  artifact: /Serilog.*\.nupkg/
+  tag: v$(appveyor_build_version)
+  on:
+    branch: master

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,40 @@
+echo "build: Build started"
+
+Push-Location $PSScriptRoot
+
+if(Test-Path .\artifacts) {
+	echo "build: Cleaning .\artifacts"
+	Remove-Item .\artifacts -Force -Recurse
+}
+
+& dotnet restore --no-cache
+
+$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
+$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+
+echo "build: Version suffix is $suffix"
+
+foreach ($src in ls src/*) {
+    Push-Location $src
+
+	echo "build: Packaging project in $src"
+
+    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --include-source
+    if($LASTEXITCODE -ne 0) { exit 1 }    
+
+    Pop-Location
+}
+
+foreach ($test in ls test/*.Tests) {
+    Push-Location $test
+
+	echo "build: Testing project in $test"
+
+    & dotnet test -c Release
+    if($LASTEXITCODE -ne 0) { exit 3 }
+
+    Pop-Location
+}
+
+Pop-Location

--- a/example/Sample/Sample.csproj
+++ b/example/Sample/Sample.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Settings.Delegates/Serilog.Settings.Delegates.csproj
+++ b/src/Serilog.Settings.Delegates/Serilog.Settings.Delegates.csproj
@@ -1,7 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Delegate support for Serilog configuration providers.</Description>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Authors>Serilog Contributors</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Serilog.Settings.Delegates</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>Serilog.Settings.Delegates</PackageId>
+    <PackageTags>serilog</PackageTags>
+    <PackageIconUrl>https://serilog.net/images/serilog-community-nuget.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/mv10/serilog-settings-delegates</PackageProjectUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <RootNamespace>Serilog</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AppVeyor blowing up because "initial_appveyor_support" branch name is truncated to "intial_ap" and then it tries to generate a nuget package named 1.0.0-initial_ap-00001 which is invalid... needs to be in dev.